### PR TITLE
Remove exim4 MTA package

### DIFF
--- a/src/pca_gophish.yml
+++ b/src/pca_gophish.yml
@@ -10,11 +10,10 @@
     # exim4 mail transfer agent (MTA) to avoid any conflicts with
     # SMTP ports 25 and 587.
     - name: Stop and disable exim4 service
-      ansible.builtin.systemd:
+      ansible.builtin.service:
         enabled: false
         name: exim4.service
         state: stopped
-      when: ansible_service_mgr == "systemd"
     - name: Uninstall exim4 packages
       ansible.builtin.apt:
         # Use "autoremove" to get rid of any exim4 dependencies

--- a/src/pca_gophish.yml
+++ b/src/pca_gophish.yml
@@ -17,6 +17,8 @@
       when: ansible_service_mgr == "systemd"
     - name: Uninstall exim4 packages
       ansible.builtin.apt:
+        # Use "autoremove" to get rid of any exim4 dependencies
+        # that are no longer needed
         autoremove: yes
         name: exim4*
         state: absent

--- a/src/pca_gophish.yml
+++ b/src/pca_gophish.yml
@@ -6,6 +6,20 @@
   roles:
     - pca_gophish_composition
   tasks:
+    # Since we are using postfix (inside Docker), we first remove the
+    # exim4 mail transfer agent (MTA) to avoid any conflicts with
+    # SMTP ports 25 and 587.
+    - name: Stop and disable exim4 service
+      ansible.builtin.systemd:
+        enabled: false
+        name: exim4.service
+        state: stopped
+      when: ansible_service_mgr == "systemd"
+    - name: Uninstall exim4 packages
+      ansible.builtin.apt:
+        autoremove: yes
+        name: exim4*
+        state: absent
     # Currently, the latest available version of docker-compose on Debian
     # Buster is 1.21.0 (see
     # https://packages.debian.org/source/buster/docker-compose).


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR removes the `exim4` mail transfer agent (MTA).

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

From #36:

> exim4 is not needed; we are using Dockerized postfix instead. By removing exim4, we avoid any conflicts for use of SMTP ports 25 and 587.

Resolves #36 and is part of the work required for cisagov/cool-system#90.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested these Ansible tasks by re-using a previously-converged Docker instance (the one I was using to test #39).  Here's what I did:
- `molecule login -h debian10_systemd`
- Manually install `exim4` packages: `apt-get install exim4`
- Start `exim4` service: `systemctl start exim4` and verify it started with `systemctl status exim4`
- Log out of Docker instance
- Add the Ansible task code from this PR to the tasks file for my test instance
- Re-converge my test instance: `molecule converge` - this was successful and clearly showed that changes occurred for the two tasks in this PR
- `molecule login -h debian10_systemd`
- Confirmed that the `exim4` service was indeed stopped (`systemctl status exim4`) and the packages had been removed (`apt remove exim4*` showed that there was nothing to remove)

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
