### PR TITLE
Get rid of default postfix credentials

### DIFF
--- a/src/pca_gophish.yml
+++ b/src/pca_gophish.yml
@@ -56,6 +56,12 @@
             src: docker-compose.production.yml
             dest: >-
               {{ pca_gophish_composition_path }}/docker-compose.production.yml
+        - name: Copy postfix users file to composition secrets directory
+          ansible.builtin.copy:
+            mode: 0644
+            src: postfix-users.txt
+            dest: >-
+              {{ pca_gophish_composition_path }}/secrets/postfix/users.txt
         - name: Set up pca-gophish-composition systemd service
           block:
             - name: Install systemd service file for pca-gophish-composition

--- a/src/postfix-users.txt
+++ b/src/postfix-users.txt
@@ -1,0 +1,12 @@
+# This file is a customized version of the file from
+# cisagov/pca-gophish-composition/secrets/postfix/users.txt
+
+# Define the users to be created at container startup.
+# If <password> is omitted for a user it will be generated and logged at startup
+# username <password>
+
+# The mailarchive user is mandatory since all mail is BCC'd to this user.
+mailarchive
+
+# Custom users
+assessment


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR overwrites the default postfix `users.txt` file with a file that does not contain any passwords.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Since we are deploying these instances into the wild, they should not use the default (test) credentials that can be found in GitHub.  It is more secure to create strong passwords for our postfix users each time the postfix container is started.

I will be working with our assessment team members to find out if this solution is good enough or if they will need additional users or passwords that don't change whenever postfix is restarted.

Resolves #35 and is part of the work required for cisagov/cool-system#90.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I verified the new Ansible task by running it in a test playbook and confirmed that it worked as expected.

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
