### PR TITLE
Bump version to rebuild AMI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,14 +3,14 @@
 # These owners will be the default owners for everything in the
 # repo. Unless a later match takes precedence, these owners will be
 # requested for review when someone opens a pull request.
-* @dav3r @felddy @jsf9k
+* @dav3r @felddy @jsf9k @mcdonnnj
 
 # Let jsf9k own the sometimes-touchy AWS and Python playbooks.
 /src/aws.yml @jsf9k
 /src/python.yml @jsf9k
 
-# Let dav3r and jsf9k share ownership of packer.pkr.hcl.
-/src/packer.pkr.hcl @dav3r @jsf9k
+# Let dav3r, jsf9k, and @mcdonnnj share ownership of packer.pkr.hcl.
+/src/packer.pkr.hcl @dav3r @jsf9k @mcdonnnj
 
 # These folks own any files in the .github directory at the root of
 # the repository and any of its subdirectories.

--- a/src/version.txt
+++ b/src/version.txt
@@ -1,1 +1,1 @@
-__version__ = "0.4.9+build.1"
+__version__ = "0.4.9+build.2"

--- a/src/version.txt
+++ b/src/version.txt
@@ -1,1 +1,1 @@
-__version__ = "0.4.9"
+__version__ = "0.4.9+build.1"


### PR DESCRIPTION
## 🗣 Description ##

This pull request bumps the version for the purpose of rebuilding the AMI.

## 💭 Motivation and context ##

The old AMI is getting long in the tooth and should be refreshed.

## 🧪 Testing ##

All automated tests pass.  I also built a new staging AMI with these changes and verified that it functions as expected. 

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
- [x] Build and test a staging AMI with these changes.

## ✅ Pre-merge checklist ##

- [x] Finalize version.

## ✅ Post-merge checklist ##

- [x] Create a release.